### PR TITLE
Fix ND Delaunay cell handle extraction for CGAL 5.6

### DIFF
--- a/src/EdgesCGALDelaunayND.cpp
+++ b/src/EdgesCGALDelaunayND.cpp
@@ -194,7 +194,11 @@ struct EdgeComputerND {
 
     std::vector<typename DT::Full_cell_const_handle> cells;
     cells.reserve(dt.number_of_finite_full_cells());
-    for(auto it=dt.finite_full_cells_begin(); it!=dt.finite_full_cells_end(); ++it) cells.push_back(it);
+    // `finite_full_cells_begin` returns a filter iterator.  Its base iterator is
+    // the compact-container iterator (the actual handle) that we need to store.
+    // Use `.base()` to retrieve it so the vector holds valid cell handles.
+    for(auto it=dt.finite_full_cells_begin(); it!=dt.finite_full_cells_end(); ++it)
+      cells.push_back(it.base());
 
 #ifdef _OPENMP
     int T = omp_get_max_threads();


### PR DESCRIPTION
## Summary
- handle CGAL dD filter iterators properly by storing their base handles

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j`
- `./build/EdgesCGALDelaunayND data/example_points.npy edges.npy`
- `python - <<'PY'
import numpy as np
arr=np.load('edges.npy')
print(arr.shape, arr.dtype)
print(arr[:5])
PY`


------
https://chatgpt.com/codex/tasks/task_b_68c7156221ac8326a9d489f7e434e67c